### PR TITLE
Update the name of completions file

### DIFF
--- a/kubectx.plugin.zsh
+++ b/kubectx.plugin.zsh
@@ -7,7 +7,7 @@ KUBECTX_DIR="$(dirname $0)/kubectx"
 COMPLETION_DIR="${KUBECTX_DIR}/completion"
 export PATH=${PATH}:${KUBECTX_DIR}
 
-if [[ ! -f "${COMPLETION_DIR}/kubectx.zsh" ]]; then
+if [[ ! -f "${COMPLETION_DIR}/_kubectx.zsh" ]]; then
   pushd "$KUBECTX_DIR"
   git submodule init
   git submodule update


### PR DESCRIPTION
Based on issue #262 (https://github.com/ahmetb/kubectx/issues/262)
completions files was renamed:
completion/{kubectx.zsh => _kubectx.zsh}
completion/{kubens.zsh => _kubens.zsh}

This changes was merged to the master branch:
https://github.com/ahmetb/kubectx/commit/bdb1ea9e9d74a2c1a1ac9d02345b7ac633dbb8eb

Signed-off-by: awerebea <awerebea.21@gmail.com>