### PR TITLE
Use https url in submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kubectx"]
 	path = kubectx
-	url = git@github.com:ahmetb/kubectx.git
+	url = https://github.com/ahmetb/kubectx.git


### PR DESCRIPTION
https://github.com/unixorn/kubectx-zshplugin/issues/11

Allows pulling submodule without ssh keys or credentials.